### PR TITLE
pull newest image after starting, xterm removed

### DIFF
--- a/src/modules/magicmirroros/filesystem/home/pi/scripts/run_magicmirroros
+++ b/src/modules/magicmirroros/filesystem/home/pi/scripts/run_magicmirroros
@@ -8,8 +8,15 @@ if [ ! -f /home/pi/magicmirror/run/docker-compose.yml ]; then
   mkdir -p /home/pi/magicmirror/mounts
 fi
 cd /home/pi/magicmirror/run
+# start mm
 docker-compose up -d
-xterm
+# pull newest docker image
+docker-compose pull
+# restart if image changed
+docker-compose up -d
+
+sleep infinity
+#xterm
 # while true
 # do
 #     sleep 10


### PR DESCRIPTION
Inserted your suggestion of pulling image while starting. Doing the pull after starting the mirror to avoid having nothing on the screen while pulling and restart the mm if the image changed.

Removed xterm because this is ugly to see on the screen before mm starts. Users should use ssh.