### PR TITLE
update git repo

### DIFF
--- a/src/modules/magicmirroros/filesystem/home/pi/scripts/check_git_repo
+++ b/src/modules/magicmirroros/filesystem/home/pi/scripts/check_git_repo
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+if [ -f $HOME/magicmirror/.git/index ]; then
+  cd $HOME/magicmirror
+  ymlchanged=$(git diff --stat master origin/master | grep rpi.yml) || true
+  cd $HOME
+  if [ ! -z "$ymlchanged" ]; then
+    echo "-----------------------------------------------------------"
+    echo "There are updates in the magicmirror git repository."
+    echo "Please cd into  ~/magicmirror/run and execute:"
+    echo ""
+    echo "git pull"
+    echo ""
+    echo "Then please update your docker-compose.yml:"
+    echo ""
+    echo "cp rpi.yml docker-compose.yml:"
+    echo ""
+    echo "If you did own changes to docker-compose.yml don't"
+    echo "forget to save it before executing the above cp command ..."
+    echo "-----------------------------------------------------------"
+  fi
+fi

--- a/src/modules/magicmirroros/filesystem/home/pi/scripts/run_magicmirroros
+++ b/src/modules/magicmirroros/filesystem/home/pi/scripts/run_magicmirroros
@@ -21,8 +21,11 @@ if [ ! -f $HOME/magicmirror/run/docker-compose.yml ]; then
   cd magicmirror/run
   cp -v rpi.yml docker-compose.yml &>> $_log
   mkdir -p $HOME/magicmirror/mounts
+else
+  cd $HOME/magicmirror/run
+  # update git repo
+  git fetch
 fi
-cd $HOME/magicmirror/run
 # start mm
 docker-compose up -d &>> $_log
 # pull newest docker image

--- a/src/modules/magicmirroros/start_chroot_script
+++ b/src/modules/magicmirroros/start_chroot_script
@@ -25,6 +25,9 @@ usermod -aG docker pi
 
 echo "WantedBy=graphical.target" >> /lib/systemd/system/docker.service
 
+# add git repo check to .bashrc
+echo "source /home/pi/scripts/check_git_repo" >> /home/pi/.bashrc
+
 # Unpack root at the end, so files are modified before
 unpack /filesystem/root /
 


### PR DESCRIPTION
closes #8

Now info's are provided how to update the mm-git-repo if the `rpi.yml` file in the repo changes and needs to be copied over the current `docker-compose.yml` file.

Did a build of MagicMirrorOS to test this.